### PR TITLE
Build with OpenCV version >4.0

### DIFF
--- a/src/calibration.cpp
+++ b/src/calibration.cpp
@@ -24,7 +24,11 @@ void Create_ColorBar()
         pColor[ba * 3 + 1] = S[s / 13];
         pColor[ba * 3 + 2] = V[v / 13 / 3];
     }
-    cv::cvtColor(color, color_bar, CV_HSV2BGR);
+    #if (CV_VERSION_MAJOR >= 4)
+        cv::cvtColor(color, color_bar, cv::COLOR_HSV2BGR);
+    #else
+        cv::cvtColor(color, color_bar, COLOR_HSV2BGR);
+    #endif
 }
 
 


### PR DESCRIPTION
Build fails, needs cv:: before CV_HSV2BGR after OpenCV version 4.0, at least that's what I suppose based on the following issuecomment: https://github.com/NVIDIA/DALI/issues/735#issuecomment-479760748