### PR TITLE
fix unused down_sample:voxel_m parameter

### DIFF
--- a/src/calibration.cpp
+++ b/src/calibration.cpp
@@ -103,12 +103,12 @@ void Calibrator::ProcessPointcloud(const pcl::PointCloud<pcl::PointXYZI>::Ptr pc
 
         pcl::PointCloud<pcl::PointXYZI>::Ptr cloud_tmp(new pcl::PointCloud<pcl::PointXYZI>);
         pcl::PointCloud<pcl::PointXYZI>::Ptr cloud_tmp_ds(new pcl::PointCloud<pcl::PointXYZI>);
-        float kLeafSize = 0.1;
+        const double leafSize = params_.down_sample_voxel;
         pcl::VoxelGrid<pcl::PointXYZI> filter_map;
-        filter_map.setLeafSize(kLeafSize, kLeafSize, kLeafSize);
+        filter_map.setLeafSize(leafSize, leafSize, leafSize);
         cloud_downsampled->clear();
 
-        pcl::octree::OctreePointCloud<pcl::PointXYZI> octree{1250 * kLeafSize};
+        pcl::octree::OctreePointCloud<pcl::PointXYZI> octree{1250.0 * leafSize};
         octree.setInputCloud(pc_filtered);
         octree.addPointsFromInputCloud();
         for (auto it = octree.leaf_depth_begin(); it != octree.leaf_depth_end(); ++it) {


### PR DESCRIPTION
The leaf size used for downsampling was using magic number instead of `down_sample:voxel_m` parameter from json config file, this change fixes it.

Additionally:
* The name was changed from `kLeafSize` to `leafSize` as `k*` variables are reserved for global/static constants, which json parameter is not as it is dynamically assigned.
* Type was changed to `const double` as the value is not changed later and `pcl::octree::OctreePointCloud` constructor takes `double`.